### PR TITLE
Fixed wind reporting

### DIFF
--- a/bin/user/aprs.py
+++ b/bin/user/aprs.py
@@ -68,10 +68,10 @@ class APRS(weewx.engine.StdService):
         else:
             data.append('%s...' % self._wind_direction_marker)
 
-        if record.get('wind_average') is not None:
+        if record.get('windSpeed') is not None:
             # Sustained one-minute wind speed (in mph)
             data.append('%s%03.f' % (self._wind_speed_marker,
-                                     record['wind_average']))
+                                     record['windSpeed']))
         else:
             data.append('%s...' % self._wind_speed_marker)
 


### PR DESCRIPTION
`wind_average` is no longer being used, according to [the weewx schema](https://github.com/weewx/weewx/blob/master/bin/schemas/wview.py). Instead, the database records are using the field titled `windSpeed`.